### PR TITLE
[Schnee, Woody] 블록 스키마, Article 라우터, 글 내용 편집 (throttle) 추가

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/lodash": "^4.17.4",
+    "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "styled-components": "^6.1.11"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,188 @@
-import Article from './components/Article';
+import React, { useState, useCallback, useEffect } from 'react';
+import { throttle } from 'lodash';
+
+interface BlockBase {
+  type: string;
+}
+
+interface HeaderBlock extends BlockBase {
+  type: 'header';
+  content: string;
+  level: number;
+}
+
+interface ParagraphBlock extends BlockBase {
+  type: 'paragraph';
+  content: string;
+}
+
+interface ListBlock extends BlockBase {
+  type: 'list';
+  items: string[];
+}
+
+interface ImageBlock extends BlockBase {
+  type: 'image';
+  url: string;
+  alt: string;
+}
+
+type Block = HeaderBlock | ParagraphBlock | ListBlock | ImageBlock;
+
+interface BlockRendererProps {
+  blocks: Block[];
+  handleContentChange: (block: Block, index: number) => void;
+}
+
+const sendArticleRequestById = async (id: number) => {
+  try {
+    const response = await fetch(`${SERVER}/api/article/${id}`);
+
+    if (!response.ok) throw new Error('Error');
+
+    return response.json();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const updateArticleRequestById = async (id: number, blocks: Block[]) => {
+  try {
+    const response = await fetch(`${SERVER}/api/article/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content: blocks }),
+    });
+
+    if (!response.ok) throw new Error('Error');
+
+    return response.json();
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const renderBlock = (
+  block: Block,
+  index: number,
+  handleInput: (e: React.FormEvent<HTMLElement>, index: number, itemIndex?: number) => void
+) => {
+  switch (block.type) {
+    case 'header':
+      const Tag = `h${block.level}` as keyof JSX.IntrinsicElements;
+      return (
+        <Tag
+          contentEditable
+          suppressContentEditableWarning
+          onInput={(e) => handleInput(e as React.FormEvent<HTMLElement>, index)}
+        >
+          {block.content}
+        </Tag>
+      );
+    case 'paragraph':
+      return (
+        <p
+          contentEditable
+          suppressContentEditableWarning
+          onInput={(e) => handleInput(e as React.FormEvent<HTMLElement>, index)}
+        >
+          {block.content}
+        </p>
+      );
+    case 'list':
+      return (
+        <ul>
+          {block.items.map((item, itemIndex) => (
+            <li
+              key={itemIndex}
+              contentEditable
+              suppressContentEditableWarning
+              onInput={(e) => handleInput(e as React.FormEvent<HTMLElement>, index, itemIndex)}
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
+      );
+    case 'image':
+      return (
+        <div>
+          <img src={block.url} alt={block.alt} />
+          <p
+            contentEditable
+            suppressContentEditableWarning
+            onInput={(e) => handleInput(e as React.FormEvent<HTMLElement>, index)}
+          >
+            {block.alt}
+          </p>
+        </div>
+      );
+    default:
+      return null;
+  }
+};
+
+const BlockRenderer: React.FC<BlockRendererProps> = ({ blocks, handleContentChange }) => {
+  const handleInput = (e: React.FormEvent<HTMLElement>, blockIndex: number, itemIndex?: number) => {
+    const newBlocks = [...blocks];
+    const block = newBlocks[blockIndex];
+
+    if (itemIndex === undefined) {
+      if ('content' in block) {
+        const updatedBlock = { ...block, content: e.currentTarget.textContent || '' };
+        newBlocks[blockIndex] = updatedBlock as typeof block;
+      }
+    } else {
+      if ('items' in block) {
+        const updatedItems = block.items.map((item, idx) =>
+          idx === itemIndex ? e.currentTarget.textContent || '' : item
+        );
+        const updatedBlock = { ...block, items: updatedItems };
+        newBlocks[blockIndex] = updatedBlock as typeof block;
+      }
+    }
+
+    handleContentChange(newBlocks[blockIndex], blockIndex);
+  };
+
+  return (
+    <div>
+      {blocks.map((block, index) => (
+        <div key={index}>{renderBlock(block, index, handleInput)}</div>
+      ))}
+    </div>
+  );
+};
+
+const SERVER = import.meta.env.VITE_SERVER;
+const FIRST_PAGE = 1;
 
 export default function App() {
+  const [blocks, setBlocks] = useState<Block[]>([]);
+
+  useEffect(() => {
+    sendArticleRequestById(FIRST_PAGE).then(({ content }) => setBlocks(content));
+  }, []);
+
+  const throttledFetch = useCallback(
+    throttle((updatedBlocks: Block[]) => {
+      updateArticleRequestById(FIRST_PAGE, updatedBlocks).then(({ content }) => setBlocks(content));
+    }, 1500),
+    []
+  );
+
+  const handleContentChange = (updatedBlock: Block, index: number) => {
+    const newBlocks = [...blocks];
+    newBlocks[index] = updatedBlock;
+    setBlocks(newBlocks);
+    throttledFetch(newBlocks);
+  };
+
   return (
-    <>
-      <Article />
-    </>
-  )
+    <div>
+      <BlockRenderer blocks={blocks} handleContentChange={handleContentChange} />
+    </div>
+  );
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -67,7 +67,7 @@ const updateArticleRequestById = async (id: number, blocks: Block[]) => {
 const renderBlock = (
   block: Block,
   index: number,
-  handleInput: (e: React.FormEvent<HTMLElement>, index: number, itemIndex?: number) => void
+  handleInput: (e: React.KeyboardEvent<HTMLElement>, index: number, itemIndex?: number) => void
 ) => {
   switch (block.type) {
     case 'header':
@@ -76,7 +76,7 @@ const renderBlock = (
         <Tag
           contentEditable
           suppressContentEditableWarning
-          onInput={(e) => handleInput(e as React.FormEvent<HTMLElement>, index)}
+          onKeyDown={(e) => handleInput(e as React.KeyboardEvent<HTMLElement>, index)}
         >
           {block.content}
         </Tag>
@@ -86,7 +86,7 @@ const renderBlock = (
         <p
           contentEditable
           suppressContentEditableWarning
-          onInput={(e) => handleInput(e as React.FormEvent<HTMLElement>, index)}
+          onKeyDown={(e) => handleInput(e as React.KeyboardEvent<HTMLElement>, index)}
         >
           {block.content}
         </p>
@@ -99,7 +99,7 @@ const renderBlock = (
               key={itemIndex}
               contentEditable
               suppressContentEditableWarning
-              onInput={(e) => handleInput(e as React.FormEvent<HTMLElement>, index, itemIndex)}
+              onKeyDown={(e) => handleInput(e as React.KeyboardEvent<HTMLElement>, index, itemIndex)}
             >
               {item}
             </li>
@@ -113,7 +113,7 @@ const renderBlock = (
           <p
             contentEditable
             suppressContentEditableWarning
-            onInput={(e) => handleInput(e as React.FormEvent<HTMLElement>, index)}
+            onKeyDown={(e) => handleInput(e as React.KeyboardEvent<HTMLElement>, index)}
           >
             {block.alt}
           </p>
@@ -125,7 +125,7 @@ const renderBlock = (
 };
 
 const BlockRenderer: React.FC<BlockRendererProps> = ({ blocks, handleContentChange }) => {
-  const handleInput = (e: React.FormEvent<HTMLElement>, blockIndex: number, itemIndex?: number) => {
+  const handleInput = (e: React.KeyboardEvent<HTMLElement>, blockIndex: number, itemIndex?: number) => {
     const newBlocks = [...blocks];
     const block = newBlocks[blockIndex];
 
@@ -168,7 +168,7 @@ export default function App() {
 
   const throttledFetch = useCallback(
     throttle((updatedBlocks: Block[]) => {
-      updateArticleRequestById(FIRST_PAGE, updatedBlocks).then(({ content }) => setBlocks(content));
+      updateArticleRequestById(FIRST_PAGE, updatedBlocks);
     }, 1500),
     []
   );
@@ -176,7 +176,6 @@ export default function App() {
   const handleContentChange = (updatedBlock: Block, index: number) => {
     const newBlocks = [...blocks];
     newBlocks[index] = updatedBlock;
-    setBlocks(newBlocks);
     throttledFetch(newBlocks);
   };
 

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 dist
 package-lock.json
 node_modules
+.env

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon src/index.ts"
+    "dev": "nodemon dist/index.js",
+    "compile": "npx tsc"
   },
   "keywords": [],
   "author": "",

--- a/server/package.json
+++ b/server/package.json
@@ -24,5 +24,6 @@
     "nodemon": "^3.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
-  }
+  },
+  "type": "module"
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,8 @@ const app: Express = express();
 const port = process.env.PORT || 3000;
 
 app.use(cors());
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 mongoose
   .connect('mongodb://localhost:27017/mydatabase')
@@ -46,10 +48,12 @@ app.get('/api/article/:articleId', async (req: Request, res: Response) => {
 app.patch('/api/article/:articleId', async (req: Request, res: Response) => {
   try {
     const { articleId } = req.params;
+    const articleIdNumber = Number(articleId);
+    console.log(req.body);
     const { content } = req.body;
 
-    const updatedArticle = await Article.findByIdAndUpdate(
-      articleId,
+    const updatedArticle = await Article.findOneAndUpdate(
+      { id: articleIdNumber },
       {
         content,
         updatedAt: new Date(),
@@ -73,13 +77,28 @@ app.listen(port, () => {
 });
 
 const initializeDb = async () => {
+  await Article.deleteMany();
   const articleCount = await Article.countDocuments();
 
   if (articleCount === 0) {
     try {
       await Article.insertMany({
         id: 1,
-        content: '테스트 내용\n테스트 내용2\n테스트 내용3',
+        content: [
+          {
+            type: 'header',
+            level: 2,
+            content: 'Hello World',
+          },
+          {
+            type: 'paragraph',
+            content: 'This is a simple paragraph.',
+          },
+          {
+            type: 'list',
+            items: ['First item', 'Second item', 'Third item'],
+          },
+        ],
         updatedAt: '2024-06-03T19:00:00+09:00',
       });
       console.log('article successfully initialized');

--- a/server/src/models/Article.ts
+++ b/server/src/models/Article.ts
@@ -1,9 +1,21 @@
-import mongoose from 'mongoose';
+import mongoose, { Schema } from 'mongoose';
+
+const BlockSchema = new Schema(
+  {
+    type: { type: String, required: true },
+    content: { type: String },
+    level: { type: Number },
+    items: { type: [String] },
+    url: { type: String },
+    alt: { type: String },
+  },
+  { _id: false }
+);
 
 const articleSchema = new mongoose.Schema({
-  id: Number,
-  content: String,
-  updatedAt: String,
+  id: { type: Number, required: true, unique: true },
+  content: { type: [BlockSchema], required: true },
+  updatedAt: { type: String, default: '1970-06-03T19:00:00+09:00' },
 });
 
 const Article = mongoose.model('Article', articleSchema);

--- a/server/src/routes/articleRouter.ts
+++ b/server/src/routes/articleRouter.ts
@@ -1,0 +1,52 @@
+import express, { Request, Response, Router } from "express";
+import Article from "../models/Article.js";
+
+const articleRouter: Router = express.Router();
+
+articleRouter.get('/:articleId', async (req: Request, res: Response) => {
+  try {
+    const { articleId } = req.params;
+    const articleIdNumber = Number(articleId);
+
+    if (isNaN(articleIdNumber)) return res.status(400).json({ message: 'Invalid article ID' });
+
+    const article = await Article.findOne({ id: articleIdNumber });
+
+    if (!article) {
+      return res.status(404).json({ message: 'Article not found' });
+    }
+
+    res.json(article);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+articleRouter.patch('/:articleId', async (req: Request, res: Response) => {
+  try {
+    const { articleId } = req.params;
+    const articleIdNumber = Number(articleId);
+    const { content } = req.body;
+
+    const updatedArticle = await Article.findOneAndUpdate(
+      { id: articleIdNumber },
+      {
+        content,
+        updatedAt: new Date(),
+      },
+      { new: true, runValidators: true }
+    );
+
+    if (!updatedArticle) {
+      return res.status(404).json({ message: 'Article not found' });
+    }
+
+    res.json(updatedArticle);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default articleRouter;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,13 +1,19 @@
 {
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs",
+        "target": "esnext",
+        "module": "esnext",
         "strict": true,
         "esModuleInterop": true,
         "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "allowSyntheticDefaultImports": true,
         "outDir": "./dist",
         "rootDir": "./src"
     },
     "include": ["src/**/*"],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "**/*.spec.ts"]
 }
+  

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,19 +1,17 @@
 {
     "compilerOptions": {
-        "target": "esnext",
-        "module": "esnext",
-        "strict": true,
-        "esModuleInterop": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        "allowSyntheticDefaultImports": true,
-        "outDir": "./dist",
-        "rootDir": "./src"
+      "module": "ES2020",
+      "target": "ES2020",
+      "forceConsistentCasingInFileNames": true,
+      "moduleResolution": "node",
+      "resolveJsonModule": true,
+      "isolatedModules": true,
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      "outDir": "./dist",
+      "rootDir": "./src"
     },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules", "**/*.spec.ts"]
-}
+    "include": ["src/**/*.ts"],
+    "exclude": ["node_modules"]
+  }
   


### PR DESCRIPTION
## 기능
- [x] Article의 스키마 (content) 를 string 대신에 객체로 변경 [#13](https://github.com/NotionTeam02/fe-notion/issues/13)
- [x] Article의 글 내용 Patch 요청 추가 [#14](https://github.com/NotionTeam02/fe-notion/issues/14)
- [x] Article의 블록 배열 렌더링 및 throttle fetch 구현 [#15](https://github.com/NotionTeam02/fe-notion/issues/15)

## 버그 수정
- [x] 서버 요청 시에 express 서버에서 body를 못받는 에러 [#16](https://github.com/NotionTeam02/fe-notion/issues/16)
- [x] express에서 import.meta 를 사용하지 못했던 버그 [#19](https://github.com/NotionTeam02/fe-notion/issues/19)